### PR TITLE
Restore merlin

### DIFF
--- a/ocaml-lsp-server/src/merlin_config.ml
+++ b/ocaml-lsp-server/src/merlin_config.ml
@@ -398,8 +398,11 @@ module DB = struct
 
   let get t uri = create t uri
 
-  let create () =
-    { running = Table.create (module String) 0; pool = Fiber.Pool.create () }
+  let create ~read_merlin_files =
+    { running = Table.create (module String) 0
+    ; pool = Fiber.Pool.create ()
+    ; read_merlin_files
+    }
 
   let run t = Fiber.Pool.run t.pool
 

--- a/ocaml-lsp-server/src/merlin_config.mli
+++ b/ocaml-lsp-server/src/merlin_config.mli
@@ -13,7 +13,7 @@ module DB : sig
 
   type t
 
-  val create : unit -> t
+  val create : read_merlin_files:bool -> t
 
   val stop : t -> unit Fiber.t
 

--- a/ocaml-lsp-server/src/ocaml_lsp_server.ml
+++ b/ocaml-lsp-server/src/ocaml_lsp_server.ml
@@ -1009,7 +1009,7 @@ let on_notification server (notification : Client_notification.t) :
     in
     state
 
-let start _read_merlin_files =
+let start read_merlin_files =
   let detached = Fiber.Pool.create () in
   let server = Fdecl.create Dyn.opaque in
   let store = Document_store.make server detached in
@@ -1049,7 +1049,7 @@ let start _read_merlin_files =
     Fdecl.set server
       (Server.make handler stream
          (State.create ~store ~merlin ~ocamlformat_rpc ~configuration ~detached
-            ~diagnostics ~symbols_thread ~wheel));
+            ~diagnostics ~symbols_thread ~wheel ~read_merlin_files));
     Fdecl.get server
   in
   let state = Server.state server in

--- a/ocaml-lsp-server/src/state.ml
+++ b/ocaml-lsp-server/src/state.ml
@@ -24,9 +24,9 @@ type t =
   }
 
 let create ~store ~merlin ~detached ~configuration ~ocamlformat_rpc ~diagnostics
-    ~symbols_thread ~wheel =
+    ~symbols_thread ~wheel ~read_merlin_files =
   { init = Uninitialized
-  ; merlin_config = Merlin_config.DB.create ()
+  ; merlin_config = Merlin_config.DB.create ~read_merlin_files
   ; store
   ; merlin
   ; detached

--- a/ocaml-lsp-server/src/state.mli
+++ b/ocaml-lsp-server/src/state.mli
@@ -32,6 +32,7 @@ val create :
   -> diagnostics:Diagnostics.t
   -> symbols_thread:Lev_fiber.Thread.t Lazy_fiber.t
   -> wheel:Lev_fiber.Timer.Wheel.t
+  -> read_merlin_files:bool
   -> t
 
 val wheel : t -> Lev_fiber.Timer.Wheel.t


### PR DESCRIPTION
Remember, I'm a total noob with this stuff (started looking OCaml stuff like a couple of weeks ago).
This is what I ended up with. I'm not too sure if we can just reuse the same logic to spawn dot-merlin-reader instead of dune, but dot-merlin-reader process seems to be created.

I did shallow manual testing for this by creating a dune project with a simple .merlin file where the build artifacts and source folders were listed. Module navigation seemed to work fine. I still don't know how to pull more information out of ocaml-lsp-server, I don't know where `Log.log` calls are printed (if you know, please tell me).

This might help you or not, I just wanted to share what I have done so far.
You can open a pull request to ocaml-lsp repo and we can ask for more help. I didn't want to steal your work, that's why I'm adding stuff here first.